### PR TITLE
Colin/Leonard - updated extra_args to opts

### DIFF
--- a/lib/cukeforker/rake_task.rb
+++ b/lib/cukeforker/rake_task.rb
@@ -6,7 +6,7 @@ module CukeForker
     attr_accessor :name
     attr_accessor :verbose
     attr_accessor :features
-    attr_accessor :extra_args
+    attr_accessor :opts
 
     def initialize(*args, &task_block)
       setup_ivars(args)
@@ -29,13 +29,13 @@ module CukeForker
 
       split = args.index("--")
       if split
-        @extra_args = args[0..(split-1)]
+        @opts = args[0..(split-1)]
         @features = args[(split+1)..-1]
       end
     end
 
     def run_cukeforker
-      unless CukeForker::Runner.run(@features, :extra_args => @extra_args)
+      unless CukeForker::Runner.run(@features, @opts)
         raise 'Test failures'
       end
     end


### PR DESCRIPTION
* fixed the the way opts are being assigned
Before:
`CukeForker::Runner.run(@features, :extra_args => @extra_args)` which made @opts being assigned as `@extra_args` value to the :extra_args key resulting in @opts not being passed to CukeForker::Runner.run() correctly
Now:
`CukeForker::Runner.run(@features, @opts)` where @opts are being passed directly to the `CukeForker::Runner.run` as an argument

* updated the name of instance variable to make it less ambiguous for caller of rake task